### PR TITLE
feat: LinkToCommit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.12
 require (
 	github.com/commitsar-app/commitsar v0.5.0
 	github.com/spf13/cobra v0.0.5
+	github.com/stretchr/testify v1.4.0
 )

--- a/internal/text/urls.go
+++ b/internal/text/urls.go
@@ -1,0 +1,12 @@
+package text
+
+import (
+	"fmt"
+)
+
+// LinkToCommit to commit provides a formatted link to a commit
+func LinkToCommit(projectURL string, commitID string) string {
+	link := fmt.Sprintf("%v/commit/%v", projectURL, commitID)
+
+	return link
+}

--- a/internal/text/urls_test.go
+++ b/internal/text/urls_test.go
@@ -1,0 +1,23 @@
+package text
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type urlTestStruct struct {
+	url string
+	commit string
+}
+
+func TestLinkToCommit(t *testing.T) {
+	tests := map[string]urlTestStruct{
+		"https://github.com/commisar-app/commitsar/commit/12345": urlTestStruct{url: "https://github.com/commisar-app/commitsar", commit:"12345"},
+	}
+
+	for expected, test := range tests {
+		link := LinkToCommit(test.url, test.commit)
+		assert.Equal(t, expected, link)
+	}
+}


### PR DESCRIPTION
- LinkToCommit formats urls according to Github style