### PR TITLE
feat(Dockerfile)!: set default Dockerfile command to publish

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ COPY --from=builder /app/build/release-notary ./release-notary
 
 RUN ln -s $PWD/release-notary /usr/local/bin
 
-CMD [ "release-notary", "log" ]
+CMD [ "release-notary", "publish" ]


### PR DESCRIPTION
BREAKING CHANGE: previously log was the default command in the Dockerfile. It is now replaced with publish.

- Publish allows users to publish to Github right now