### PR TITLE
feat: pass commit hash to release note generator

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -57,8 +57,12 @@ var publishCmd = &cobra.Command{
 				return err
 			}
 
+			parsedCommit := text.ParseCommitMessage(commitObject.Message)
+
+			parsedCommit.Hash = commitObject.Hash
+
 			parsedCommits = append(parsedCommits,
-				text.ParseCommitMessage(commitObject.Message),
+				parsedCommit,
 			)
 		}
 


### PR DESCRIPTION
- publish command will now pass commit hash info into release notes function
- allows for a richer release note format with links to exact commits