### PR TITLE
improvement: pass Commit object in split_section and release_notes

### DIFF
--- a/internal/text/release_notes.go
+++ b/internal/text/release_notes.go
@@ -27,7 +27,7 @@ func ReleaseNotes(sections Sections) string {
 	return builder.String()
 }
 
-func buildSection(category string, commits []string) string {
+func buildSection(category string, commits []Commit) string {
 	builder := strings.Builder{}
 
 	builder.WriteString(buildHeading(category))
@@ -66,12 +66,12 @@ func buildHeading(category string) string {
 	return builder.String()
 }
 
-func buildCommitLog(commits []string) string {
+func buildCommitLog(commits []Commit) string {
 	builder := strings.Builder{}
 
 	for _, commit := range commits {
 		builder.WriteString("- ")
-		builder.WriteString(commit)
+		builder.WriteString(commit.Heading)
 		builder.WriteString("\n")
 	}
 

--- a/internal/text/release_notes_test.go
+++ b/internal/text/release_notes_test.go
@@ -10,10 +10,10 @@ func TestReleaseNotes(t *testing.T) {
 	expected := "\n\n## Features :rocket:\n\n- ci test\n\n## Bug fixes :bug:\n\n- huge bug\n\n## Chores and Improvements :wrench:\n\n- testing\n- this should end up in chores\n\n## Other :package:\n\n- merge master in something\n- random\n\n"
 
 	sections := Sections{
-		Features: []string{"ci test"},
-		Chores:   []string{"testing", "this should end up in chores"},
-		Bugs:     []string{"huge bug"},
-		Others:   []string{"merge master in something", "random"},
+		Features: []Commit{Commit{Category: "feat", Scope: "ci", Heading: "ci test"}},
+		Chores:   []Commit{Commit{Category: "chore", Scope: "", Heading: "testing"}, Commit{Category: "improvement", Scope: "", Heading: "this should end up in chores"}},
+		Bugs:     []Commit{Commit{Category: "bug", Scope: "", Heading: "huge bug"}},
+		Others:   []Commit{Commit{Category: "other", Scope: "", Heading: "merge master in something"}, Commit{Category: "bs", Scope: "", Heading: "random"}},
 	}
 
 	releaseNotes := ReleaseNotes(sections)
@@ -25,7 +25,7 @@ func TestReleaseNotesWithMissingSections(t *testing.T) {
 	expected := "\n\n## Features :rocket:\n\n- ci test\n\n"
 
 	sections := Sections{
-		Features: []string{"ci test"},
+		Features: []Commit{Commit{Heading: "ci test"}},
 	}
 
 	releaseNotes := ReleaseNotes(sections)

--- a/internal/text/split_sections.go
+++ b/internal/text/split_sections.go
@@ -2,10 +2,10 @@ package text
 
 // Sections are sections used by release notes. Please check expected-output.md
 type Sections struct {
-	Features []string
-	Chores   []string
-	Bugs     []string
-	Others   []string
+	Features []Commit
+	Chores   []Commit
+	Bugs     []Commit
+	Others   []Commit
 }
 
 // SplitSections accepts categorised commits and further organises them into separate sections for release notes
@@ -19,26 +19,26 @@ func SplitSections(categorisedCommits []Commit) Sections {
 		"fix": 		   "bug",
 	}
 
-	var features []string
-	var chores []string
-	var bugs []string
-	var other []string
+	var features []Commit
+	var chores []Commit
+	var bugs []Commit
+	var other []Commit
 
 	for _, commit := range categorisedCommits {
 		if categoryMappings[commit.Category] == "feat" {
-			features = append(features, commit.Heading)
+			features = append(features, commit)
 		}
 
 		if categoryMappings[commit.Category] == "bug" {
-			bugs = append(bugs, commit.Heading)
+			bugs = append(bugs, commit)
 		}
 
 		if categoryMappings[commit.Category] == "chore" {
-			chores = append(chores, commit.Heading)
+			chores = append(chores, commit)
 		}
 
 		if categoryMappings[commit.Category] == "other" || categoryMappings[commit.Category] == "" {
-			other = append(other, commit.Heading)
+			other = append(other, commit)
 		}
 	}
 

--- a/internal/text/split_sections_test.go
+++ b/internal/text/split_sections_test.go
@@ -18,10 +18,10 @@ func TestSplitSections(t *testing.T) {
 	}
 
 	expected := Sections{
-		Features: []string{"ci test"},
-		Chores:   []string{"testing", "this should end up in chores"},
-		Bugs:     []string{"huge bug", "bug fix"},
-		Others:   []string{"merge master in something", "random"},
+		Features: []Commit{Commit{Category: "feat", Scope: "ci", Heading: "ci test"}},
+		Chores:   []Commit{Commit{Category: "chore", Scope: "", Heading: "testing"}, Commit{Category: "improvement", Scope: "", Heading: "this should end up in chores"}},
+		Bugs:     []Commit{Commit{Category: "bug", Scope: "", Heading: "huge bug"}, Commit{Category: "fix", Scope: "", Heading: "bug fix"}},
+		Others:   []Commit{Commit{Category: "other", Scope: "", Heading: "merge master in something"}, Commit{Category: "bs", Scope: "", Heading: "random"}},
 	}
 
 	sections := SplitSections(dataset)


### PR DESCRIPTION
- in order to add extra information such as Hash it's important that the whole Commit object is passed down
- also allows for extra grouping based on scope