### PR TITLE
chore: skip changelog in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,8 +19,4 @@ checksum:
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  skip: true


### PR DESCRIPTION
- changelog is handled by release notary therefore there is no need to have goreleaser handle it additionally