### PR TITLE
feat: add Commit hashes to release notes

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -59,7 +59,7 @@ var publishCmd = &cobra.Command{
 
 			parsedCommit := text.ParseCommitMessage(commitObject.Message)
 
-			parsedCommit.Hash = commitObject.Hash
+			parsedCommit.Hash = text.Hash(commitObject.Hash)
 
 			parsedCommits = append(parsedCommits,
 				parsedCommit,

--- a/internal/text/commit.go
+++ b/internal/text/commit.go
@@ -1,0 +1,19 @@
+package text
+
+import "encoding/hex"
+
+// Commit is a parsed commit that contains information about category, scope and heading
+type Commit struct {
+	Category string
+	Heading  string
+	Body     string
+	Scope    string
+	Hash     Hash
+}
+
+// Hash describes a commit hash
+type Hash [20]byte
+
+func (h Hash) String() string {
+	return hex.EncodeToString(h[:])
+}

--- a/internal/text/parse_commits.go
+++ b/internal/text/parse_commits.go
@@ -9,15 +9,6 @@ var (
 	expectedFormatRegex = regexp.MustCompile(`^(?P<type>\S+?)(?P<scope>\(\S+\)?)?!?:\s(?P<message>.+)\n`)
 )
 
-// Commit is a parsed commit that contains information about category, scope and heading
-type Commit struct {
-	Category string
-	Heading  string
-	Body     string
-	Scope    string
-	Hash     [20]byte
-}
-
 // ParseCommitMessage creates a slice of Commits that contain information about category and scope parsed from commit message
 func ParseCommitMessage(commitMessage string) Commit {
 	match := expectedFormatRegex.FindStringSubmatch(commitMessage)

--- a/internal/text/release_notes.go
+++ b/internal/text/release_notes.go
@@ -71,6 +71,9 @@ func buildCommitLog(commits []Commit) string {
 
 	for _, commit := range commits {
 		builder.WriteString("- ")
+		// Short version of hash usable on Github
+		builder.WriteString(commit.Hash.String()[:7])
+		builder.WriteString(" ")
 		builder.WriteString(commit.Heading)
 		builder.WriteString("\n")
 	}

--- a/internal/text/release_notes_test.go
+++ b/internal/text/release_notes_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestReleaseNotes(t *testing.T) {
-	expected := "\n\n## Features :rocket:\n\n- ci test\n\n## Bug fixes :bug:\n\n- huge bug\n\n## Chores and Improvements :wrench:\n\n- testing\n- this should end up in chores\n\n## Other :package:\n\n- merge master in something\n- random\n\n"
+	expected := "\n\n## Features :rocket:\n\n- 0000000 ci test\n\n## Bug fixes :bug:\n\n- 0000000 huge bug\n\n## Chores and Improvements :wrench:\n\n- 0000000 testing\n- 0000000 this should end up in chores\n\n## Other :package:\n\n- 0000000 merge master in something\n- 0000000 random\n\n"
 
 	sections := Sections{
 		Features: []Commit{Commit{Category: "feat", Scope: "ci", Heading: "ci test"}},
@@ -22,7 +22,7 @@ func TestReleaseNotes(t *testing.T) {
 }
 
 func TestReleaseNotesWithMissingSections(t *testing.T) {
-	expected := "\n\n## Features :rocket:\n\n- ci test\n\n"
+	expected := "\n\n## Features :rocket:\n\n- 0000000 ci test\n\n"
 
 	sections := Sections{
 		Features: []Commit{Commit{Heading: "ci test"}},


### PR DESCRIPTION
- adds short version of commit hash to release notes
- moves Commit into commit.go
- adds Hash as a type with String() method