### PR TITLE
fix(gitlab): use tags instead of releases api

### DIFF
--- a/internal/gitlab/latest_release.go
+++ b/internal/gitlab/latest_release.go
@@ -12,7 +12,7 @@ var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 // LatestRelease gets the release on current tag. https://docs.gitlab.com/ee/api/releases/#get-a-release-by-a-tag-name Gitlab does not have support for latest release in API.
 func (g *Gitlab) LatestRelease() (*release.Release, error) {
-	url := fmt.Sprintf("%v/projects/%v/releases/%v", g.apiURL, g.projectID, g.tagName)
+	url := fmt.Sprintf("%v/projects/%v/repository/tags/%v", g.apiURL, g.projectID, g.tagName)
 	response, err := g.client.Get(url)
 
 	if err != nil {

--- a/internal/gitlab/publish.go
+++ b/internal/gitlab/publish.go
@@ -11,9 +11,9 @@ import (
 
 // Publish publishes a Release https://developer.github.com/v3/repos/releases/#edit-a-release
 func (g *Gitlab) Publish(release *release.Release) error {
-	url := fmt.Sprintf("%v/projects/%v/releases/%v", g.apiURL, g.projectID, g.tagName)
+	url := fmt.Sprintf("%v/projects/%v/repository/tags/%v/release", g.apiURL, g.projectID, g.tagName)
 
-	jsonBody, err := json.Marshal(gitlabRelease{Name: release.Name, Message: release.Message})
+	jsonBody, err := json.Marshal(gitlabRelease{Message: release.Message})
 
 	if err != nil {
 		return err


### PR DESCRIPTION
- gitlab, unlike github, does not create a release per tag
- this will get the message from the tag and create a new release