### PR TITLE
chore(gitlab): use POST instead of PUT

### DIFF
--- a/internal/gitlab/publish.go
+++ b/internal/gitlab/publish.go
@@ -19,7 +19,7 @@ func (g *Gitlab) Publish(release *release.Release) error {
 		return err
 	}
 
-	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(jsonBody))
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonBody))
 
 	if err != nil {
 		return err


### PR DESCRIPTION
- PUT is used only to update, in this case we are creating a new Release