### PR TITLE
fix(gitlab): use existing release information to adjust method

### DIFF
--- a/internal/gitlab/latest_release.go
+++ b/internal/gitlab/latest_release.go
@@ -24,13 +24,20 @@ func (g *Gitlab) LatestRelease() (*release.Release, error) {
 
 	defer response.Body.Close()
 
-	var glRelease gitlabRelease
+	var glTag gitlabTag
 
-	err = json.NewDecoder(response.Body).Decode(&glRelease)
+	err = json.NewDecoder(response.Body).Decode(&glTag)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return &release.Release{ID: g.projectID, Tag: g.tagName, Name: glRelease.Name, Message: glRelease.Message}, nil
+	message := ""
+
+	// If a release already exists it's hidden in this field
+	if glTag.Release.Message != "" {
+		message = glTag.Release.Message
+	}
+
+	return &release.Release{ID: g.projectID, Tag: g.tagName, Name: glTag.Name, Message: message}, nil
 }

--- a/internal/gitlab/publish.go
+++ b/internal/gitlab/publish.go
@@ -8,7 +8,7 @@ import (
 	"github.com/commitsar-app/release-notary/internal/release"
 )
 
-// Publish publishes a Release https://developer.github.com/v3/repos/releases/#edit-a-release
+// Publish publishes a Release https://docs.gitlab.com/ee/api/tags.html#create-a-new-release
 func (g *Gitlab) Publish(release *release.Release) error {
 	// By default we are creating a new release
 	method := "POST"

--- a/internal/gitlab/service.go
+++ b/internal/gitlab/service.go
@@ -18,6 +18,16 @@ type gitlabRelease struct {
 	Message string `json:"description"`
 }
 
+// tagRelease is metadata used by gitlab in a tag https://docs.gitlab.com/ee/api/tags.html#get-a-single-repository-tag
+type tagRelease struct {
+	Message string `json:"description"`
+}
+
+type gitlabTag struct {
+	Name    string     `json:"name"`
+	Release tagRelease `json:"release"`
+}
+
 // CreateGitlabService creates an instance of the Gitlab service struct
 func CreateGitlabService(projectID int, apiURL, tagName, token string) (*Gitlab, error) {
 	if projectID == 0 {


### PR DESCRIPTION
- uses existing metadata from tag GET to determine if release notes are already attached