### PR TITLE
fix(gitlab): publisher would crash on 201 code

### DIFF
--- a/internal/gitlab/publish.go
+++ b/internal/gitlab/publish.go
@@ -40,7 +40,8 @@ func (g *Gitlab) Publish(release *release.Release) error {
 		return err
 	}
 
-	if response.StatusCode != 200 {
+	// 201 is used when a new release is attached to an existing tag
+	if response.StatusCode != 200 && response.StatusCode != 201 {
 		return fmt.Errorf("%v %v returned %v code with error: %v", method, url, response.StatusCode, response.Status)
 	}
 


### PR DESCRIPTION
- release was done correctly, but app would fail
- gitlab uses 201 to signify that a new release was attached to an existing tag