### PR TITLE
fix: don't crash when prvious tag is not available

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -40,7 +40,7 @@ var publishCmd = &cobra.Command{
 
 		lastTag, err := repo.PreviousTag(currentCommit.Hash)
 
-		if err != nil {
+		if err != nil && err != history.ErrPrevTagNotAvailable {
 			return err
 		}
 


### PR DESCRIPTION
- on new repos PreviousTag is not available, this would result in a crash