### PR TITLE
fix: add all commits if previous tag is not available

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/commitsar-app/git/pkg"
+	history "github.com/commitsar-app/git/pkg"
 	"github.com/commitsar-app/release-notary/internal/releaser"
 	"github.com/commitsar-app/release-notary/internal/text"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
 func init() {
@@ -42,6 +43,11 @@ var publishCmd = &cobra.Command{
 
 		if err != nil && err != history.ErrPrevTagNotAvailable {
 			return err
+		}
+
+		// If previous tag is not available, provide empty hash so that all commits are iterated.
+		if err == history.ErrPrevTagNotAvailable {
+			lastTag = plumbing.Hash{}
 		}
 
 		commits, err := repo.CommitsBetween(currentCommit.Hash, lastTag)

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
+	gopkg.in/src-d/go-git.v4 v4.13.1
 )


### PR DESCRIPTION
- in new repositories previous tag is not available, this will allow for iterating all unreleased commits