### PR TITLE
chore(ci): Use docker image

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Commitsar Action
-        uses: commitsar-app/commitsar@v0.6.6
+        uses: docker://commitsar/commitsar:0.8.0


### PR DESCRIPTION
Instead of having to build the thing every time, it should use the docker image that you are already building.