### PR TITLE
chore!: rework release notes to use maps

### DIFF
--- a/internal/text/release_notes.go
+++ b/internal/text/release_notes.go
@@ -3,25 +3,25 @@ package text
 import "strings"
 
 // ReleaseNotes generates the output mentioned in the expected-output.md
-func ReleaseNotes(sections Sections) string {
+func ReleaseNotes(sections map[string][]Commit) string {
 	builder := strings.Builder{}
 	// Extra lines at the start to make sure formatting starts correctly
 	builder.WriteString("\n\n")
 
-	if len(sections.Features) > 0 {
-		builder.WriteString(buildSection("features", sections.Features))
+	if len(sections["features"]) > 0 {
+		builder.WriteString(buildSection("features", sections["features"]))
 	}
 
-	if len(sections.Bugs) > 0 {
-		builder.WriteString(buildSection("bugs", sections.Bugs))
+	if len(sections["bugs"]) > 0 {
+		builder.WriteString(buildSection("bugs", sections["bugs"]))
 	}
 
-	if len(sections.Chores) > 0 {
-		builder.WriteString(buildSection("chores", sections.Chores))
+	if len(sections["chores"]) > 0 {
+		builder.WriteString(buildSection("chores", sections["chores"]))
 	}
 
-	if len(sections.Others) > 0 {
-		builder.WriteString(buildSection("others", sections.Others))
+	if len(sections["others"]) > 0 {
+		builder.WriteString(buildSection("others", sections["others"]))
 	}
 
 	return builder.String()

--- a/internal/text/release_notes_test.go
+++ b/internal/text/release_notes_test.go
@@ -19,11 +19,11 @@ func TestReleaseNotes(t *testing.T) {
 
 	expected := string(b)
 
-	sections := Sections{
-		Features: []Commit{Commit{Category: "feat", Scope: "ci", Heading: "ci test"}},
-		Chores:   []Commit{Commit{Category: "chore", Scope: "", Heading: "testing"}, Commit{Category: "improvement", Scope: "", Heading: "this should end up in chores"}},
-		Bugs:     []Commit{Commit{Category: "bug", Scope: "", Heading: "huge bug"}},
-		Others:   []Commit{Commit{Category: "other", Scope: "", Heading: "merge master in something"}, Commit{Category: "bs", Scope: "", Heading: "random"}},
+	sections := map[string][]Commit{
+		"features": []Commit{Commit{Category: "feat", Scope: "ci", Heading: "ci test"}},
+		"chores":   []Commit{Commit{Category: "chore", Scope: "", Heading: "testing"}, Commit{Category: "improvement", Scope: "", Heading: "this should end up in chores"}},
+		"bugs":     []Commit{Commit{Category: "bug", Scope: "", Heading: "huge bug"}},
+		"others":   []Commit{Commit{Category: "other", Scope: "", Heading: "merge master in something"}, Commit{Category: "bs", Scope: "", Heading: "random"}},
 	}
 
 	releaseNotes := ReleaseNotes(sections)
@@ -34,8 +34,8 @@ func TestReleaseNotes(t *testing.T) {
 func TestReleaseNotesWithMissingSections(t *testing.T) {
 	expected := "\n\n## Features :rocket:\n\n- 0000000 ci test\n\n"
 
-	sections := Sections{
-		Features: []Commit{Commit{Heading: "ci test"}},
+	sections := map[string][]Commit{
+		"features": []Commit{Commit{Heading: "ci test"}},
 	}
 
 	releaseNotes := ReleaseNotes(sections)

--- a/internal/text/split_sections.go
+++ b/internal/text/split_sections.go
@@ -1,51 +1,31 @@
 package text
 
-// Sections are sections used by release notes. Please check expected-output.md
-type Sections struct {
-	Features []Commit
-	Chores   []Commit
-	Bugs     []Commit
-	Others   []Commit
-}
+import "log"
 
 // SplitSections accepts categorised commits and further organises them into separate sections for release notes
-func SplitSections(categorisedCommits []Commit) Sections {
+func SplitSections(categorisedCommits []Commit) map[string][]Commit {
 	categoryMappings := map[string]string{
-		"feat":        "feat",
-		"chore":       "chore",
-		"improvement": "chore",
-		"bug":         "bug",
+		"feat":        "features",
+		"chore":       "chores",
+		"improvement": "chores",
+		"bug":         "bugs",
 		"other":       "other",
-		"fix": 		   "bug",
+		"fix":         "bugs",
 	}
 
-	var features []Commit
-	var chores []Commit
-	var bugs []Commit
-	var other []Commit
+	sections := make(map[string][]Commit)
 
 	for _, commit := range categorisedCommits {
-		if categoryMappings[commit.Category] == "feat" {
-			features = append(features, commit)
+		var category = categoryMappings[commit.Category]
+		if category != "other" {
+			log.Println(category)
+			sections[category] = append(sections[category], commit)
 		}
 
-		if categoryMappings[commit.Category] == "bug" {
-			bugs = append(bugs, commit)
-		}
-
-		if categoryMappings[commit.Category] == "chore" {
-			chores = append(chores, commit)
-		}
-
-		if categoryMappings[commit.Category] == "other" || categoryMappings[commit.Category] == "" {
-			other = append(other, commit)
+		if category == "other" || category == "" {
+			sections["others"] = append(sections["others"], commit)
 		}
 	}
 
-	return Sections{
-		Features: features,
-		Chores:   chores,
-		Bugs:     bugs,
-		Others:   other,
-	}
+	return sections
 }

--- a/internal/text/split_sections_test.go
+++ b/internal/text/split_sections_test.go
@@ -17,17 +17,17 @@ func TestSplitSections(t *testing.T) {
 		Commit{Category: "fix", Scope: "", Heading: "bug fix"},
 	}
 
-	expected := Sections{
-		Features: []Commit{Commit{Category: "feat", Scope: "ci", Heading: "ci test"}},
-		Chores:   []Commit{Commit{Category: "chore", Scope: "", Heading: "testing"}, Commit{Category: "improvement", Scope: "", Heading: "this should end up in chores"}},
-		Bugs:     []Commit{Commit{Category: "bug", Scope: "", Heading: "huge bug"}, Commit{Category: "fix", Scope: "", Heading: "bug fix"}},
-		Others:   []Commit{Commit{Category: "other", Scope: "", Heading: "merge master in something"}, Commit{Category: "bs", Scope: "", Heading: "random"}},
+	expected := map[string][]Commit{
+		"features": []Commit{Commit{Category: "feat", Scope: "ci", Heading: "ci test"}},
+		"chores":   []Commit{Commit{Category: "chore", Scope: "", Heading: "testing"}, Commit{Category: "improvement", Scope: "", Heading: "this should end up in chores"}},
+		"bugs":     []Commit{Commit{Category: "bug", Scope: "", Heading: "huge bug"}, Commit{Category: "fix", Scope: "", Heading: "bug fix"}},
+		"others":   []Commit{Commit{Category: "other", Scope: "", Heading: "merge master in something"}, Commit{Category: "bs", Scope: "", Heading: "random"}},
 	}
 
 	sections := SplitSections(dataset)
 
-	assert.Equal(t, expected.Features, sections.Features)
-	assert.Equal(t, expected.Chores, sections.Chores)
-	assert.Equal(t, expected.Bugs, sections.Bugs)
-	assert.Equal(t, expected.Others, sections.Others)
+	assert.Equal(t, expected["features"], sections["features"])
+	assert.Equal(t, expected["chores"], sections["chores"])
+	assert.Equal(t, expected["bugs"], sections["bugs"])
+	assert.Equal(t, expected["others"], sections["others"])
 }


### PR DESCRIPTION
BREAKING CHANGE: Sections struct has been removed. 

- maps are now used instead. This is a pre-requisite for dynamic mappings using a config file.