### PR TITLE
refactor: break up release note builder in separate files

### DIFF
--- a/internal/text/build_commit_log.go
+++ b/internal/text/build_commit_log.go
@@ -1,0 +1,15 @@
+package text
+
+import "strings"
+
+func buildCommitLog(commits []Commit) string {
+	builder := strings.Builder{}
+
+	for _, commit := range commits {
+		builder.WriteString(buildSingleCommit(commit))
+	}
+
+	builder.WriteString("\n")
+
+	return builder.String()
+}

--- a/internal/text/build_heading.go
+++ b/internal/text/build_heading.go
@@ -1,0 +1,24 @@
+package text
+
+import (
+	"fmt"
+	"strings"
+)
+
+func buildHeading(category string) string {
+	builder := strings.Builder{}
+
+	builder.WriteString("## ")
+
+	heading := fmt.Sprintf("%v ", sectionHeadings[category].title)
+
+	builder.WriteString(heading)
+
+	icon := fmt.Sprintf(":%v:", sectionHeadings[category].icon)
+
+	builder.WriteString(icon)
+
+	builder.WriteString("\n\n")
+
+	return builder.String()
+}

--- a/internal/text/build_section.go
+++ b/internal/text/build_section.go
@@ -1,0 +1,12 @@
+package text
+
+import "strings"
+
+func buildSection(category string, commits []Commit) string {
+	builder := strings.Builder{}
+
+	builder.WriteString(buildHeading(category))
+	builder.WriteString(buildCommitLog(commits))
+
+	return builder.String()
+}

--- a/internal/text/build_single_commit.go
+++ b/internal/text/build_single_commit.go
@@ -1,0 +1,16 @@
+package text
+
+import "strings"
+
+func buildSingleCommit(commit Commit) string {
+	builder := strings.Builder{}
+
+	builder.WriteString("- ")
+	// Short version of hash usable on Github
+	builder.WriteString(commit.Hash.String()[:7])
+	builder.WriteString(" ")
+	builder.WriteString(commit.Heading)
+	builder.WriteString("\n")
+
+	return builder.String()
+}

--- a/internal/text/release_notes.go
+++ b/internal/text/release_notes.go
@@ -1,7 +1,6 @@
 package text
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -26,50 +25,6 @@ func ReleaseNotes(sections map[string][]Commit) string {
 	if len(sections["others"]) > 0 {
 		builder.WriteString(buildSection("others", sections["others"]))
 	}
-
-	return builder.String()
-}
-
-func buildSection(category string, commits []Commit) string {
-	builder := strings.Builder{}
-
-	builder.WriteString(buildHeading(category))
-	builder.WriteString(buildCommitLog(commits))
-
-	return builder.String()
-}
-
-func buildHeading(category string) string {
-	builder := strings.Builder{}
-
-	builder.WriteString("## ")
-
-	heading := fmt.Sprintf("%v ", sectionHeadings[category].title)
-
-	builder.WriteString(heading)
-
-	icon := fmt.Sprintf(":%v:", sectionHeadings[category].icon)
-
-	builder.WriteString(icon)
-
-	builder.WriteString("\n\n")
-
-	return builder.String()
-}
-
-func buildCommitLog(commits []Commit) string {
-	builder := strings.Builder{}
-
-	for _, commit := range commits {
-		builder.WriteString("- ")
-		// Short version of hash usable on Github
-		builder.WriteString(commit.Hash.String()[:7])
-		builder.WriteString(" ")
-		builder.WriteString(commit.Heading)
-		builder.WriteString("\n")
-	}
-
-	builder.WriteString("\n")
 
 	return builder.String()
 }


### PR DESCRIPTION
- release_notes file was getting too big, this simply break it up