### PR TITLE
refactor: use struct for ReleaseNote methods

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -105,9 +105,9 @@ var publishCmd = &cobra.Command{
 
 		sections := text.SplitSections(parsedCommits)
 
-		releaseNotes := text.ReleaseNotes(sections)
+		releaseNotes := text.ReleaseNotes{}
 
-		err = releaseService.Release(releaseNotes)
+		err = releaseService.Release(releaseNotes.Generate(sections))
 
 		if err != nil {
 			return err

--- a/internal/text/build_commit_log.go
+++ b/internal/text/build_commit_log.go
@@ -2,11 +2,11 @@ package text
 
 import "strings"
 
-func buildCommitLog(commits []Commit) string {
+func (r *ReleaseNotes) buildCommitLog(commits []Commit) string {
 	builder := strings.Builder{}
 
 	for _, commit := range commits {
-		builder.WriteString(buildSingleCommit(commit))
+		builder.WriteString(r.buildSingleCommit(commit))
 	}
 
 	builder.WriteString("\n")

--- a/internal/text/build_heading.go
+++ b/internal/text/build_heading.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-func buildHeading(category string) string {
+func (r *ReleaseNotes) buildHeading(category string) string {
 	builder := strings.Builder{}
 
 	builder.WriteString("## ")

--- a/internal/text/build_section.go
+++ b/internal/text/build_section.go
@@ -2,11 +2,11 @@ package text
 
 import "strings"
 
-func buildSection(category string, commits []Commit) string {
+func (r *ReleaseNotes) buildSection(category string, commits []Commit) string {
 	builder := strings.Builder{}
 
-	builder.WriteString(buildHeading(category))
-	builder.WriteString(buildCommitLog(commits))
+	builder.WriteString(r.buildHeading(category))
+	builder.WriteString(r.buildCommitLog(commits))
 
 	return builder.String()
 }

--- a/internal/text/build_single_commit.go
+++ b/internal/text/build_single_commit.go
@@ -2,7 +2,16 @@ package text
 
 import "strings"
 
-func buildSingleCommit(commit Commit) string {
+func (r *ReleaseNotes) buildSingleCommit(commit Commit) string {
+	builder := strings.Builder{}
+
+	commitMessage := buildSimpleCommit(commit)
+	builder.WriteString(commitMessage)
+
+	return builder.String()
+}
+
+func buildSimpleCommit(commit Commit) string {
 	builder := strings.Builder{}
 
 	builder.WriteString("- ")

--- a/internal/text/release_notes.go
+++ b/internal/text/release_notes.go
@@ -4,26 +4,31 @@ import (
 	"strings"
 )
 
-// ReleaseNotes generates the output mentioned in the expected-output.md
-func ReleaseNotes(sections map[string][]Commit) string {
+// ReleaseNotes holds the required settings for generating ReleaseNotes
+type ReleaseNotes struct {
+	Simple bool
+}
+
+// Generate generates the output mentioned in the expected-output.md
+func (r *ReleaseNotes) Generate(sections map[string][]Commit) string {
 	builder := strings.Builder{}
 	// Extra lines at the start to make sure formatting starts correctly
 	builder.WriteString("\n\n")
 
 	if len(sections["features"]) > 0 {
-		builder.WriteString(buildSection("features", sections["features"]))
+		builder.WriteString(r.buildSection("features", sections["features"]))
 	}
 
 	if len(sections["bugs"]) > 0 {
-		builder.WriteString(buildSection("bugs", sections["bugs"]))
+		builder.WriteString(r.buildSection("bugs", sections["bugs"]))
 	}
 
 	if len(sections["chores"]) > 0 {
-		builder.WriteString(buildSection("chores", sections["chores"]))
+		builder.WriteString(r.buildSection("chores", sections["chores"]))
 	}
 
 	if len(sections["others"]) > 0 {
-		builder.WriteString(buildSection("others", sections["others"]))
+		builder.WriteString(r.buildSection("others", sections["others"]))
 	}
 
 	return builder.String()

--- a/internal/text/release_notes_test.go
+++ b/internal/text/release_notes_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestReleaseNotes(t *testing.T) {
+	notes := ReleaseNotes{}
 	file, err := os.Open("../../expected-output.md")
 
 	defer file.Close()
@@ -26,19 +27,20 @@ func TestReleaseNotes(t *testing.T) {
 		"others":   []Commit{Commit{Category: "other", Scope: "", Heading: "merge master in something"}, Commit{Category: "bs", Scope: "", Heading: "random"}},
 	}
 
-	releaseNotes := ReleaseNotes(sections)
+	releaseNotes := notes.Generate(sections)
 
 	assert.Equal(t, expected, releaseNotes)
 }
 
 func TestReleaseNotesWithMissingSections(t *testing.T) {
+	notes := ReleaseNotes{}
 	expected := "\n\n## Features :rocket:\n\n- 0000000 ci test\n\n"
 
 	sections := map[string][]Commit{
 		"features": []Commit{Commit{Heading: "ci test"}},
 	}
 
-	releaseNotes := ReleaseNotes(sections)
+	releaseNotes := notes.Generate(sections)
 
 	assert.Equal(t, expected, releaseNotes)
 }


### PR DESCRIPTION
- to avoid having to pass down settings through many functions