### PR TITLE
fix: parse commit body

### DIFF
--- a/internal/text/parse_commits.go
+++ b/internal/text/parse_commits.go
@@ -6,28 +6,31 @@ import (
 )
 
 var (
-	expectedFormatRegex = regexp.MustCompile(`^(?P<type>\S+?)(?P<scope>\(\S+\)?)?!?:\s(?P<message>.+)\n`)
+	expectedFormatRegex = regexp.MustCompile(`(?s)^(?P<category>\S+?)?(?P<scope>\(\S+\))?(?P<breaking>!?)?: (?P<heading>[^\n\r]+)?([\n\r]{2}(?P<body>.*))?`)
 )
 
 // ParseCommitMessage creates a slice of Commits that contain information about category and scope parsed from commit message
 func ParseCommitMessage(commitMessage string) Commit {
 	match := expectedFormatRegex.FindStringSubmatch(commitMessage)
+
 	if len(match) > 0 {
-		// in case of no scope
-		category := match[1]
-		message := match[2]
-		scope := ""
+		result := make(map[string]string)
 
-		// if 2nd match is found then scope is present
-		if match[3] != "" {
-			message = match[3]
-			scope = match[2]
-
-			scope = strings.Replace(scope, "(", "", 1)
-			scope = strings.Replace(scope, ")", "", 1)
+		for i, name := range expectedFormatRegex.SubexpNames() {
+			if i != 0 && name != "" {
+				result[name] = match[i]
+			}
 		}
 
-		return Commit{Category: category, Heading: message, Scope: scope}
+		category := result["category"]
+		scope := result["scope"]
+		heading := result["heading"]
+		body := result["body"]
+
+		scope = strings.Replace(scope, "(", "", 1)
+		scope = strings.Replace(scope, ")", "", 1)
+
+		return Commit{Category: category, Heading: heading, Scope: scope, Body: body}
 	}
 
 	return Commit{Category: "other", Heading: commitMessage, Scope: ""}

--- a/internal/text/parse_commits_test.go
+++ b/internal/text/parse_commits_test.go
@@ -9,10 +9,10 @@ import (
 func TestParseCommitMessage(t *testing.T) {
 
 	tests := map[string]Commit{
-		"chore: testing\n":                  Commit{Category: "chore", Scope: "", Heading: "testing"},
-		"feat(ci): ci test\n":               Commit{Category: "feat", Scope: "ci", Heading: "ci test"},
-		"merge master in something\n":       Commit{Category: "other", Scope: "", Heading: "merge master in something\n"},
-		"chore: test\n something more here": Commit{Category: "chore", Scope: "", Heading: "test"},
+		"chore: testing\n":                   Commit{Category: "chore", Scope: "", Heading: "testing"},
+		"feat(ci): ci test\n":                Commit{Category: "feat", Scope: "ci", Heading: "ci test"},
+		"merge master in something\n":        Commit{Category: "other", Scope: "", Heading: "merge master in something\n"},
+		"chore: test\n\nsomething more here": Commit{Category: "chore", Scope: "", Heading: "test", Body: "something more here"},
 	}
 
 	for test, expected := range tests {


### PR DESCRIPTION
- commit body was not being parsed by ParseCommitMessage
- simplifies the logic for parsing the commit to use named groups instead of using match indexes like before